### PR TITLE
Feature: Add literal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# vNext
+
+- Added support for type literal types, ie `foo(bar : false, baz : null, foobar : 123)`
+
 # v0.0.15
 
 **Features**

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -276,6 +276,24 @@ const transformer: (program : ts.Program) => ts.TransformerFactory<ts.SourceFile
                         return ts.factory.createIdentifier('Array');
                 }
                 
+                if (ts.isLiteralTypeNode(typeNode)) {
+                    let literal = typeNode.literal;
+
+                    if (ts.isLiteralExpression(literal))
+                        return literal;
+                    if (ts.isPrefixUnaryExpression(literal))
+                        return literal;
+                    
+                    switch (literal.kind) {
+                        case ts.SyntaxKind.NullKeyword:
+                            return ts.factory.createIdentifier('null');
+                        case ts.SyntaxKind.FalseKeyword:
+                            return ts.factory.createIdentifier('false');
+                        case ts.SyntaxKind.TrueKeyword:
+                            return ts.factory.createIdentifier('true');
+                    }
+                }
+                
                 if (ts.isTupleTypeNode(typeNode)) {
                     if (!extended)
                         return ts.factory.createIdentifier('Object');

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -891,6 +891,86 @@ describe('RTTI: ', () => {
                 let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
                 expect(type()).to.equal(Number);
             })
+            it('emits for literal null', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : null { 
+                                return 123; 
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.equal(null);
+            })
+            it('emits for literal false', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : false { 
+                                return false;
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.equal(false);
+            })
+            it('emits for literal true', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : true { 
+                                return true;
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.equal(true);
+            })
+            it('emits for literal expression', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : 3 { 
+                                return 3;
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.equal(3);
+            })
+            it('emits for unary literal expression', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : -3 { 
+                                return -3;
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.equal(-3);
+            })
             it('emits for returned Function', async () => {
                 let exports = await runSimple({
                     code: `
@@ -1005,22 +1085,6 @@ describe('RTTI: ', () => {
         
                 let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
                 expect(type()).to.eql({ TΦ: T_UNION, t: [ String, Number ] });
-            })
-            it.only('emits for union return type', async () => {
-                let exports = await runSimple({
-                    code: `
-                        export class A { }
-                        export class B { }
-                        export class C {
-                            method(hello : A, world : B) : string | null { 
-                                return 123; 
-                            }
-                        }
-                    `
-                });
-        
-                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
-                expect(type()).to.eql({ TΦ: T_UNION, t: [ String, null ] });
             })
             it('emits for intersection return type', async () => {
                 let exports = await runSimple({

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -1006,6 +1006,22 @@ describe('RTTI: ', () => {
                 let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
                 expect(type()).to.eql({ TΦ: T_UNION, t: [ String, Number ] });
             })
+            it.only('emits for union return type', async () => {
+                let exports = await runSimple({
+                    code: `
+                        export class A { }
+                        export class B { }
+                        export class C {
+                            method(hello : A, world : B) : string | null { 
+                                return 123; 
+                            }
+                        }
+                    `
+                });
+        
+                let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
+                expect(type()).to.eql({ TΦ: T_UNION, t: [ String, null ] });
+            })
             it('emits for intersection return type', async () => {
                 let exports = await runSimple({
                     code: `


### PR DESCRIPTION
Adds support for literal types `null`, `true`, `false`, as well as expressions (123, -123, "blah").

Fixes #5 