### PR TITLE
Interfaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}\\dist\\test.js",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/dist/**/*.js"
+            ]
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # vNext
 
 - Added support for `void` type
+- Breaking: You must now use ReflectedClass.for(MyClass) instead of new ReflectedClass(MyClass)
+- Instances of ReflectedClass are now cached and shared. As a result all 
+  instances of ReflectedClass are now [sealed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal)
 - Breaking: `ReflectedMethod#parameterTypes` now has type `ReflectedTypeRef[]` 
   which allows them to express the full range of types possible. Previously the raw type refs (for instance type 
   resolvers such as `() => String`) was returned here which inappropriately exposed the underlying metadata format.
+- Added support for is() type predicates and as() casting to `ReflectedTypeRef` 
+  for ease of use
+- Added several more variants of `ReflectedTypeRef` to match how the 
+  capabilities of the library have evolved
 - `ReflectedMethod#parameterTypes` can now source metadata from `design:paramtypes`
-- Added `ReflectedTypeRef#classConstructor` to conveniently obtain the constructor for the type reference 
-  (when applicable)
 
 # v0.0.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # vNext
 
 - Added support for `void` type
+- Breaking: `ReflectedMethod#parameterTypes` now has type `ReflectedTypeRef[]` 
+  which allows them to express the full range of types possible. Previously the raw type refs (for instance type 
+  resolvers such as `() => String`) was returned here which inappropriately exposed the underlying metadata format.
+- `ReflectedMethod#parameterTypes` can now source metadata from `design:paramtypes`
+- Added `ReflectedTypeRef#classConstructor` to conveniently obtain the constructor for the type reference 
+  (when applicable)
 
 # v0.0.19
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ class B {
     }
 }
 
-let aClass = new ReflectedClass(A);
+let aClass = ReflectedClass.for(A);
 console.log(aClass.parameterNames); // ["someValue", "someOtherValue"]
 console.log(aClass.parameters[0].name); // "someValue"
 console.log(aClass.getParameter('someValue').type); // Number
 console.log(aClass.getParameter('someOtherValue').type); // String
 
-let bClass = new ReflectedClass(B);
+let bClass = ReflectedClass.for(B);
 console.log(bClass.propertyNames) // ["foo", "bar"]
 console.log(bClass.getProperty('foo').type) // A
 console.log(bClass.getProperty('foo').visibility) // "private"

--- a/src/common/flags.ts
+++ b/src/common/flags.ts
@@ -19,3 +19,9 @@ export const T_TUPLE        = 'T';
 export const T_ARRAY        = '[';
 export const T_THIS         = 't';
 export const T_GENERIC      = 'g';
+
+export type RtSimpleType<T> = { TΦ: T };
+export type RtVoidType     = RtSimpleType<typeof T_VOID>;
+export type RtUnknownType  = RtSimpleType<typeof T_UNKNOWN>
+export type RtAnyType      = RtSimpleType<typeof T_ANY>;
+export type RtThisType     = RtSimpleType<typeof T_THIS>;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,1 +1,2 @@
 export * from './flags';
+export * from './interface';

--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -1,4 +1,4 @@
-export interface Interface {
+export interface Interface<T = any> {
     name : string;
     prototype : any;
     identity : symbol;

--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -1,4 +1,4 @@
-export interface Interface<T = any> {
+export interface InterfaceToken<T = any> {
     name : string;
     prototype : any;
     identity : symbol;

--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -1,0 +1,5 @@
+export interface Interface {
+    name : string;
+    prototype : any;
+    identity : symbol;
+}

--- a/src/lib/reflect-interface.test.ts
+++ b/src/lib/reflect-interface.test.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+import { describe } from "razmin";
+import { ReflectedClass } from ".";
+import { compile, runSimple } from "../runner.test";
+import { reify, reflect } from "./reflect";
+
+describe('reflect<T>()', it => {
+    it('reifies and reflects', async () => {
+        let exports = await runSimple({
+            modules: {
+                "typescript-rtti": { reify, reflect },
+            },
+            code: `
+                import { reflect } from 'typescript-rtti';
+                export interface Something {}
+                export const reflectedInterface = reflect<Something>();
+            `
+        })
+
+        expect(exports.reflectedInterface).to.be.instanceOf(ReflectedClass);
+        expect((exports.reflectedInterface as ReflectedClass).class).to.equal(exports.IΦSomething);
+    });
+    it(`doesn't rewrite other calls into typescript-rtti`, async () => {
+        let exports = await runSimple({ 
+            modules: {
+                'typescript-rtti': {
+                    other(passed?) {
+                        return passed ?? 123;
+                    }
+                }
+            },
+            code: `
+                import { reflect, other } from 'typescript-rtti';
+                interface A {}
+                export const value1 = other();
+                export const value2 = other<A>();
+            `
+        });
+
+        expect(exports.value1).to.equal(123);
+        expect(exports.value2).to.equal(123);
+    })
+    it(`doesn't rewrite any calls for other libraries`, async () => {
+        let exports = await runSimple({ 
+            modules: {
+                'other': {
+                    reflect(passed?) {
+                        return passed ?? 123;
+                    },
+                    reify(passed?) {
+                        return passed ?? 123;
+                    }
+                }
+            },
+            code: `
+                import { reflect, reify } from 'other';
+                interface A {}
+                export const value1 = reflect();
+                export const value2 = reflect<A>();
+                export const value3 = reify();
+                export const value4 = reify<A>();
+            `
+        });
+
+        expect(exports.value1).to.equal(123);
+        expect(exports.value2).to.equal(123);
+        expect(exports.value3).to.equal(123);
+        expect(exports.value4).to.equal(123);
+    })
+});

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -407,6 +407,22 @@ describe('ReflectedProperty', it => {
         expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.true;
         expect(new ReflectedClass(B).getProperty('bar').type.isClass(String)).to.be.true;
     })
+    it('reflects parameter details', () => {
+        class B {
+        }
+        Reflect.defineMetadata('rt:m', ['helloWorld'], B);
+        Reflect.defineMetadata('rt:t', () => Boolean, B.prototype, 'helloWorld');
+        Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], B.prototype, 'helloWorld');
+        
+        let helloWorld = new ReflectedClass(B).getMethod('helloWorld');
+        expect(helloWorld.parameterNames).to.eql(['message', 'size']);
+        expect(helloWorld.parameterTypes[0].isClass(String)).to.be.true;
+        expect(helloWorld.parameterTypes[0].isClass(Number)).to.be.false;
+        expect(helloWorld.parameterTypes[1].isClass(Number)).to.be.true;
+        expect(helloWorld.parameterTypes[1].isClass(String)).to.be.false;
+
+        expect(helloWorld.parameterTypes.map(pt => pt.classConstructor)).to.eql([String, Number]);
+    })
     it('reflects static property names with design:type', () => {
         class B {
             static foo = 123;

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "razmin";
 import { expect } from "chai";
 import { ReflectedClass } from "./reflect";
-import { Interface } from "../common";
+import { InterfaceToken } from "../common";
 import * as flags from '../common/flags';
 import { ReflectedClassRef } from ".";
 
@@ -98,7 +98,7 @@ describe('ReflectedClass', it => {
         expect(refClass.getProperty('foo').type.isClass(Number)).to.be.true;
     });
     it('reflects reified interfaces', () => {
-        let IΦFoo : Interface = { name: 'Foo', prototype: {}, identity: Symbol('Foo (interface)') };
+        let IΦFoo : InterfaceToken = { name: 'Foo', prototype: {}, identity: Symbol('Foo (interface)') };
 
         Reflect.defineMetadata('rt:P', ['foobar', 'foobaz'], IΦFoo);
         Reflect.defineMetadata('rt:m', ['helloWorld'], IΦFoo);

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -9,7 +9,7 @@ describe('ReflectedClass', it => {
     it('can reflect constructor parameters', () => {
         class A {}
         Reflect.defineMetadata('rt:p', [{n: 'a', t: () => Number}, {n: 'b', t: () => String}], A);
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
 
         expect(refClass.parameters.length).to.equal(2);
 
@@ -24,7 +24,7 @@ describe('ReflectedClass', it => {
             constructor(a, b, c) { }
         }
         Reflect.defineMetadata('design:paramtypes', [String, Number, String], A);
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
 
         expect(refClass.parameters.length).to.equal(3);
 
@@ -43,38 +43,38 @@ describe('ReflectedClass', it => {
     });
     it('can reflect abstract', () => {
         class A {}
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
         expect(refClass.flags.isAbstract).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_ABSTRACT}`, A);
-        refClass = ReflectedClass.for(A);
+        refClass = ReflectedClass.new(A);
         expect(refClass.flags.isAbstract).to.be.true;
     });
     it('can reflect public', () => {
         class A {}
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
         expect(refClass.flags.isPublic).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PUBLIC}`, A);
-        refClass = ReflectedClass.for(A);
+        refClass = ReflectedClass.new(A);
         expect(refClass.visibility).to.equal('public');
     });
     it('can reflect private', () => {
         class A {}
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
         expect(refClass.flags.isPrivate).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PRIVATE}`, A);
-        refClass = ReflectedClass.for(A);
+        refClass = ReflectedClass.new(A);
         expect(refClass.visibility).to.equal('private');
     });
     it('can reflect protected', () => {
         class A {}
-        let refClass = ReflectedClass.for(A);
+        let refClass = ReflectedClass.new(A);
         expect(refClass.flags.isProtected).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PROTECTED}`, A);
-        refClass = ReflectedClass.for(A);
+        refClass = ReflectedClass.new(A);
         expect(refClass.visibility).to.equal('protected');
     });
     it('can reflect upon inherited methods', () => {
@@ -84,7 +84,7 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => String, A.prototype, 'bar');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], A);
 
-        let refClass = ReflectedClass.for(B);
+        let refClass = ReflectedClass.new(B);
         expect(refClass.getMethod('foo').returnType.isClass(Number)).to.be.true;
     });
     it('can reflect upon inherited properties', () => {
@@ -94,7 +94,7 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => String, A.prototype, 'bar');
         Reflect.defineMetadata('rt:P', ['foo', 'bar'], A);
 
-        let refClass = ReflectedClass.for(B);
+        let refClass = ReflectedClass.new(B);
         expect(refClass.getProperty('foo').type.isClass(Number)).to.be.true;
     });
     it('reflects reified interfaces', () => {
@@ -107,9 +107,9 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => Boolean, IΦFoo.prototype, 'helloWorld');
         Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], IΦFoo.prototype, 'helloWorld');
 
-        let foobar = ReflectedClass.for(IΦFoo).getProperty('foobar');
-        let foobaz = ReflectedClass.for(IΦFoo).getProperty('foobaz');
-        let helloWorld = ReflectedClass.for(IΦFoo).getMethod('helloWorld');
+        let foobar = ReflectedClass.new(IΦFoo).getProperty('foobar');
+        let foobaz = ReflectedClass.new(IΦFoo).getProperty('foobaz');
+        let helloWorld = ReflectedClass.new(IΦFoo).getMethod('helloWorld');
 
         expect(foobar.type.kind).to.equal('class');
         expect(foobar.type.isClass(Number)).to.be.true;
@@ -143,7 +143,7 @@ describe('ReflectedClass', it => {
 
         Reflect.defineMetadata('rt:i', [ () => IΦSomething, () => IΦSomethingElse ], A);
 
-        let klass = ReflectedClass.for(A);
+        let klass = ReflectedClass.new(A);
 
         expect(klass.interfaces.length).to.equal(2);
         expect(klass.interfaces[0].isInterface(IΦSomething)).to.be.true;
@@ -160,7 +160,7 @@ describe('ReflectedMethod', it => {
             bar() { }
         }
 
-        let refClass = ReflectedClass.for(B);
+        let refClass = ReflectedClass.new(B);
         expect(refClass.ownMethodNames).to.eql(['foo', 'bar']);
         expect(refClass.ownMethods[0].name).to.equal('foo');
         expect(refClass.ownMethods[1].name).to.equal('bar');
@@ -171,73 +171,73 @@ describe('ReflectedMethod', it => {
         }
 
         Reflect.defineMetadata('design:returntype', String, B.prototype, 'foo');
-        let refClass = ReflectedClass.for(B);
+        let refClass = ReflectedClass.new(B);
         expect(refClass.ownMethods.find(x => x.name === 'foo').returnType.isClass(String)).to.be.true;
     })
     it('reflects public', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PUBLIC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(A).getMethod('foo').visibility).to.equal('public');
     })
     it('reflects protected', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PROTECTED}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('protected');
+        expect(ReflectedClass.new(A).getMethod('foo').visibility).to.equal('protected');
     })
     it('reflects private', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PRIVATE}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('private');
+        expect(ReflectedClass.new(A).getMethod('foo').visibility).to.equal('private');
     })
     it('reflects async', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').isAsync).to.be.false
+        expect(ReflectedClass.new(B).getMethod('foo').isAsync).to.be.false
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_ASYNC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(ReflectedClass.for(A).getMethod('foo').isAsync).to.be.true
+        expect(ReflectedClass.new(A).getMethod('foo').isAsync).to.be.true
     })
     it('reflects return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => Number, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').returnType.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('bar').returnType.isUnknown()).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').returnType.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('bar').returnType.isUnknown()).to.be.true;
     })
     it('reflects generic return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => ({ TΦ: flags.T_GENERIC, t: Promise, p: [ String ]}), B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').returnType.isClass(Promise)).to.be.false;
-        expect(ReflectedClass.for(B).getMethod('foo').returnType.isGeneric(Promise)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').returnType.isPromise(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').returnType.isClass(Promise)).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').returnType.isGeneric(Promise)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').returnType.isPromise(String)).to.be.true;
     })
     it('reflects static method return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B, 'foo');
         Reflect.defineMetadata('rt:t', () => Number, B, 'foo');
         Reflect.defineMetadata('rt:Sm', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getStaticMethod('foo').returnType.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getStaticMethod('bar').returnType.isUnknown()).to.be.true;
+        expect(ReflectedClass.new(B).getStaticMethod('foo').returnType.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticMethod('bar').returnType.isUnknown()).to.be.true;
     })
     it('reflects static method names without metadata', () => {
         class B {
@@ -245,7 +245,7 @@ describe('ReflectedMethod', it => {
             static bar() { }
         }
 
-        expect(ReflectedClass.for(B).staticMethodNames).to.eql(['foo', 'bar'])
+        expect(ReflectedClass.new(B).staticMethodNames).to.eql(['foo', 'bar'])
     })
     it('reflects static method return type using design:returntype', () => {
         class B {
@@ -254,22 +254,22 @@ describe('ReflectedMethod', it => {
         }
 
         Reflect.defineMetadata('design:returntype', RegExp, B, 'foo');
-        expect(ReflectedClass.for(B).getStaticMethod('foo').returnType.isClass(RegExp)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticMethod('foo').returnType.isClass(RegExp)).to.be.true;
     })
     it('reflects parameters', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:p', [{n:'a', t: () => String}, {n:'b', t: () => Boolean}], B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].name).to.equal('a');
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').name).to.equal('a');
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
 
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].name).to.equal('b');
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').name).to.equal('b');
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
     })
     it('reflects parameter optionality', () => {
         class B {}
@@ -277,23 +277,23 @@ describe('ReflectedMethod', it => {
         Reflect.defineMetadata('rt:p', [{n:'a', t: () => String}, {n:'b', t: () => Boolean, f: `${flags.F_OPTIONAL}`}], B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
 
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].name).to.equal('a');
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').name).to.equal('a');
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').flags.isOptional).to.be.false;
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].flags.isOptional).to.be.false;
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].isOptional).to.be.false;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').isOptional).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').name).to.equal('a');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').flags.isOptional).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].flags.isOptional).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[0].isOptional).to.be.false;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('a').isOptional).to.be.false;
         
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].name).to.equal('b');
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').name).to.equal('b');
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].flags.isOptional).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').flags.isOptional).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].isOptional).to.be.true;
-        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').isOptional).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').name).to.equal('b');
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].flags.isOptional).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').flags.isOptional).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').parameters[1].isOptional).to.be.true;
+        expect(ReflectedClass.new(B).getMethod('foo').getParameter('b').isOptional).to.be.true;
     })
 });
 
@@ -302,56 +302,56 @@ describe('ReflectedProperty', it => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PUBLIC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(A).getProperty('foo').visibility).to.equal('public');
     })
     it('reflects protected', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PROTECTED}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('protected');
+        expect(ReflectedClass.new(A).getProperty('foo').visibility).to.equal('protected');
     })
     it('reflects private', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.new(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PRIVATE}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('private');
+        expect(ReflectedClass.new(A).getProperty('foo').visibility).to.equal('private');
     })
     it('reflects readonly', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(ReflectedClass.for(B).getProperty('foo').isReadonly).to.be.false
+        expect(ReflectedClass.new(B).getProperty('foo').isReadonly).to.be.false
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_READONLY}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(ReflectedClass.for(A).getProperty('foo').isReadonly).to.be.true
+        expect(ReflectedClass.new(A).getProperty('foo').isReadonly).to.be.true
     })
     it('reflects type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => Number, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => String, B.prototype, 'bar');
         Reflect.defineMetadata('rt:P', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects null type as class Object and as null', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => null, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        let prop = ReflectedClass.for(B).getProperty('foo');
+        let prop = ReflectedClass.new(B).getProperty('foo');
 
         expect(prop.type.kind === 'literal').to.be.true;
 
@@ -366,102 +366,102 @@ describe('ReflectedProperty', it => {
         Reflect.defineMetadata('rt:t', () => true, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.false;
     })
     it('reflects false type as class Boolean and as false', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => false, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.false;
     })
     it('reflects 123 type as class Number and as 123', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => 123, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(124)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(124)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects string literal type as class String and as the literal', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => 'foobaz', B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('foobaz')).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('not-it')).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral('foobaz')).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral('not-it')).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects undefined literal type as undefined', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => undefined, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Object)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Function)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(undefined)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Object)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Function)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(String)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(undefined)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects void type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => ({ TΦ: 'V' }), B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(ReflectedClass.for(B).getProperty('foo').type.kind).to.equal('void');
-        expect(ReflectedClass.for(B).getProperty('foo').type.isVoid).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Function)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(undefined)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.kind).to.equal('void');
+        expect(ReflectedClass.new(B).getProperty('foo').type.isVoid()).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Function)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(String)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(undefined)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects static type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => Number, B, 'foo');
         Reflect.defineMetadata('rt:t', () => String, B, 'bar');
         Reflect.defineMetadata('rt:SP', ['foo', 'bar'], B);
-        expect(ReflectedClass.for(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects type with design:type', () => {
         class B {}
         Reflect.defineMetadata('design:type', Number, B.prototype, 'foo');
         Reflect.defineMetadata('design:type', String, B.prototype, 'bar');
-        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects parameter details', () => {
         class B {
@@ -470,7 +470,7 @@ describe('ReflectedProperty', it => {
         Reflect.defineMetadata('rt:t', () => Boolean, B.prototype, 'helloWorld');
         Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], B.prototype, 'helloWorld');
         
-        let helloWorld = ReflectedClass.for(B).getMethod('helloWorld');
+        let helloWorld = ReflectedClass.new(B).getMethod('helloWorld');
         expect(helloWorld.parameterNames).to.eql(['message', 'size']);
         expect(helloWorld.parameterTypes[0].isClass(String)).to.be.true;
         expect(helloWorld.parameterTypes[0].isClass(Number)).to.be.false;
@@ -485,7 +485,7 @@ describe('ReflectedProperty', it => {
             static bar = 'val';
         }
 
-        expect(ReflectedClass.for(B).ownStaticPropertyNames).to.eql(['foo', 'bar']);
+        expect(ReflectedClass.new(B).ownStaticPropertyNames).to.eql(['foo', 'bar']);
     })
     it('reflects static type with design:type', () => {
         class B {
@@ -494,7 +494,7 @@ describe('ReflectedProperty', it => {
         }
         Reflect.defineMetadata('design:type', Number, B, 'foo');
         Reflect.defineMetadata('design:type', String, B, 'bar');
-        expect(ReflectedClass.for(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
-        expect(ReflectedClass.for(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.new(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
     })
 });

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -374,7 +374,7 @@ describe('ReflectedProperty', it => {
         expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
         expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
-    it.only('reflects void type', () => {
+    it('reflects void type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => ({ TΦ: 'V' }), B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -1,6 +1,7 @@
 import { describe } from "razmin";
 import { expect } from "chai";
-import { ReflectedClass, Interface } from "./reflect";
+import { ReflectedClass } from "./reflect";
+import { Interface } from "../common";
 import * as flags from '../common/flags';
 
 describe('ReflectedClass', it => {

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -3,12 +3,13 @@ import { expect } from "chai";
 import { ReflectedClass } from "./reflect";
 import { Interface } from "../common";
 import * as flags from '../common/flags';
+import { ReflectedClassRef } from ".";
 
 describe('ReflectedClass', it => {
     it('can reflect constructor parameters', () => {
         class A {}
         Reflect.defineMetadata('rt:p', [{n: 'a', t: () => Number}, {n: 'b', t: () => String}], A);
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
 
         expect(refClass.parameters.length).to.equal(2);
 
@@ -23,7 +24,7 @@ describe('ReflectedClass', it => {
             constructor(a, b, c) { }
         }
         Reflect.defineMetadata('design:paramtypes', [String, Number, String], A);
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
 
         expect(refClass.parameters.length).to.equal(3);
 
@@ -42,38 +43,38 @@ describe('ReflectedClass', it => {
     });
     it('can reflect abstract', () => {
         class A {}
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
         expect(refClass.flags.isAbstract).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_ABSTRACT}`, A);
-        refClass = new ReflectedClass(A);
+        refClass = ReflectedClass.for(A);
         expect(refClass.flags.isAbstract).to.be.true;
     });
     it('can reflect public', () => {
         class A {}
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
         expect(refClass.flags.isPublic).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PUBLIC}`, A);
-        refClass = new ReflectedClass(A);
+        refClass = ReflectedClass.for(A);
         expect(refClass.visibility).to.equal('public');
     });
     it('can reflect private', () => {
         class A {}
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
         expect(refClass.flags.isPrivate).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PRIVATE}`, A);
-        refClass = new ReflectedClass(A);
+        refClass = ReflectedClass.for(A);
         expect(refClass.visibility).to.equal('private');
     });
     it('can reflect protected', () => {
         class A {}
-        let refClass = new ReflectedClass(A);
+        let refClass = ReflectedClass.for(A);
         expect(refClass.flags.isProtected).to.be.false;
 
         Reflect.defineMetadata('rt:f', `C${flags.F_PROTECTED}`, A);
-        refClass = new ReflectedClass(A);
+        refClass = ReflectedClass.for(A);
         expect(refClass.visibility).to.equal('protected');
     });
     it('can reflect upon inherited methods', () => {
@@ -83,7 +84,7 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => String, A.prototype, 'bar');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], A);
 
-        let refClass = new ReflectedClass(B);
+        let refClass = ReflectedClass.for(B);
         expect(refClass.getMethod('foo').returnType.isClass(Number)).to.be.true;
     });
     it('can reflect upon inherited properties', () => {
@@ -93,7 +94,7 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => String, A.prototype, 'bar');
         Reflect.defineMetadata('rt:P', ['foo', 'bar'], A);
 
-        let refClass = new ReflectedClass(B);
+        let refClass = ReflectedClass.for(B);
         expect(refClass.getProperty('foo').type.isClass(Number)).to.be.true;
     });
     it('reflects reified interfaces', () => {
@@ -106,9 +107,9 @@ describe('ReflectedClass', it => {
         Reflect.defineMetadata('rt:t', () => Boolean, IΦFoo.prototype, 'helloWorld');
         Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], IΦFoo.prototype, 'helloWorld');
 
-        let foobar = new ReflectedClass(IΦFoo).getProperty('foobar');
-        let foobaz = new ReflectedClass(IΦFoo).getProperty('foobaz');
-        let helloWorld = new ReflectedClass(IΦFoo).getMethod('helloWorld');
+        let foobar = ReflectedClass.for(IΦFoo).getProperty('foobar');
+        let foobaz = ReflectedClass.for(IΦFoo).getProperty('foobaz');
+        let helloWorld = ReflectedClass.for(IΦFoo).getMethod('helloWorld');
 
         expect(foobar.type.kind).to.equal('class');
         expect(foobar.type.isClass(Number)).to.be.true;
@@ -122,7 +123,7 @@ describe('ReflectedClass', it => {
         expect(helloWorld.returnType.isClass(Boolean)).to.be.true;
         expect(helloWorld.returnType.isClass(Number)).to.be.false;
         expect(helloWorld.parameterNames).to.eql(['message', 'size']);
-        expect(helloWorld.parameterTypes.map(pt => pt.classConstructor)).to.eql([String, Number]);
+        expect(helloWorld.parameterTypes.map(pt => pt.as('class').class)).to.eql([String, Number]);
     });
     it('reflects implemented interfaces', () => {
 
@@ -142,7 +143,7 @@ describe('ReflectedClass', it => {
 
         Reflect.defineMetadata('rt:i', [ () => IΦSomething, () => IΦSomethingElse ], A);
 
-        let klass = new ReflectedClass(A);
+        let klass = ReflectedClass.for(A);
 
         expect(klass.interfaces.length).to.equal(2);
         expect(klass.interfaces[0].isInterface(IΦSomething)).to.be.true;
@@ -159,7 +160,7 @@ describe('ReflectedMethod', it => {
             bar() { }
         }
 
-        let refClass = new ReflectedClass(B);
+        let refClass = ReflectedClass.for(B);
         expect(refClass.ownMethodNames).to.eql(['foo', 'bar']);
         expect(refClass.ownMethods[0].name).to.equal('foo');
         expect(refClass.ownMethods[1].name).to.equal('bar');
@@ -170,73 +171,73 @@ describe('ReflectedMethod', it => {
         }
 
         Reflect.defineMetadata('design:returntype', String, B.prototype, 'foo');
-        let refClass = new ReflectedClass(B);
+        let refClass = ReflectedClass.for(B);
         expect(refClass.ownMethods.find(x => x.name === 'foo').returnType.isClass(String)).to.be.true;
     })
     it('reflects public', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(new ReflectedClass(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PUBLIC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(new ReflectedClass(A).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('public');
     })
     it('reflects protected', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(new ReflectedClass(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PROTECTED}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(new ReflectedClass(A).getMethod('foo').visibility).to.equal('protected');
+        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('protected');
     })
     it('reflects private', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(new ReflectedClass(B).getMethod('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getMethod('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PRIVATE}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(new ReflectedClass(A).getMethod('foo').visibility).to.equal('private');
+        expect(ReflectedClass.for(A).getMethod('foo').visibility).to.equal('private');
     })
     it('reflects async', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], B);
-        expect(new ReflectedClass(B).getMethod('foo').isAsync).to.be.false
+        expect(ReflectedClass.for(B).getMethod('foo').isAsync).to.be.false
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_ASYNC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo'], A);
-        expect(new ReflectedClass(A).getMethod('foo').isAsync).to.be.true
+        expect(ReflectedClass.for(A).getMethod('foo').isAsync).to.be.true
     })
     it('reflects return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => Number, B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getMethod('foo').returnType.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('bar').returnType.isUnknown()).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').returnType.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('bar').returnType.isUnknown()).to.be.true;
     })
     it('reflects generic return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => ({ TΦ: flags.T_GENERIC, t: Promise, p: [ String ]}), B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getMethod('foo').returnType.isClass(Promise)).to.be.false;
-        expect(new ReflectedClass(B).getMethod('foo').returnType.isGeneric(Promise)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').returnType.isPromise(String)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').returnType.isClass(Promise)).to.be.false;
+        expect(ReflectedClass.for(B).getMethod('foo').returnType.isGeneric(Promise)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').returnType.isPromise(String)).to.be.true;
     })
     it('reflects static method return type', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B, 'foo');
         Reflect.defineMetadata('rt:t', () => Number, B, 'foo');
         Reflect.defineMetadata('rt:Sm', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getStaticMethod('foo').returnType.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getStaticMethod('bar').returnType.isUnknown()).to.be.true;
+        expect(ReflectedClass.for(B).getStaticMethod('foo').returnType.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticMethod('bar').returnType.isUnknown()).to.be.true;
     })
     it('reflects static method names without metadata', () => {
         class B {
@@ -244,7 +245,7 @@ describe('ReflectedMethod', it => {
             static bar() { }
         }
 
-        expect(new ReflectedClass(B).staticMethodNames).to.eql(['foo', 'bar'])
+        expect(ReflectedClass.for(B).staticMethodNames).to.eql(['foo', 'bar'])
     })
     it('reflects static method return type using design:returntype', () => {
         class B {
@@ -253,22 +254,22 @@ describe('ReflectedMethod', it => {
         }
 
         Reflect.defineMetadata('design:returntype', RegExp, B, 'foo');
-        expect(new ReflectedClass(B).getStaticMethod('foo').returnType.isClass(RegExp)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticMethod('foo').returnType.isClass(RegExp)).to.be.true;
     })
     it('reflects parameters', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:p', [{n:'a', t: () => String}, {n:'b', t: () => Boolean}], B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].name).to.equal('a');
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').name).to.equal('a');
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].name).to.equal('a');
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').name).to.equal('a');
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
 
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].name).to.equal('b');
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').name).to.equal('b');
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].name).to.equal('b');
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').name).to.equal('b');
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
     })
     it('reflects parameter optionality', () => {
         class B {}
@@ -276,23 +277,23 @@ describe('ReflectedMethod', it => {
         Reflect.defineMetadata('rt:p', [{n:'a', t: () => String}, {n:'b', t: () => Boolean, f: `${flags.F_OPTIONAL}`}], B.prototype, 'foo');
         Reflect.defineMetadata('rt:m', ['foo', 'bar'], B);
 
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].name).to.equal('a');
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').name).to.equal('a');
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').flags.isOptional).to.be.false;
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].flags.isOptional).to.be.false;
-        expect(new ReflectedClass(B).getMethod('foo').parameters[0].isOptional).to.be.false;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('a').isOptional).to.be.false;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].name).to.equal('a');
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').name).to.equal('a');
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').flags.isOptional).to.be.false;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].flags.isOptional).to.be.false;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[0].isOptional).to.be.false;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('a').isOptional).to.be.false;
         
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].name).to.equal('b');
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').name).to.equal('b');
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].flags.isOptional).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').flags.isOptional).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').parameters[1].isOptional).to.be.true;
-        expect(new ReflectedClass(B).getMethod('foo').getParameter('b').isOptional).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].name).to.equal('b');
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').name).to.equal('b');
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].flags.isOptional).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').flags.isOptional).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').parameters[1].isOptional).to.be.true;
+        expect(ReflectedClass.for(B).getMethod('foo').getParameter('b').isOptional).to.be.true;
     })
 });
 
@@ -301,56 +302,56 @@ describe('ReflectedProperty', it => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(new ReflectedClass(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PUBLIC}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(new ReflectedClass(A).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('public');
     })
     it('reflects protected', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(new ReflectedClass(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PROTECTED}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(new ReflectedClass(A).getProperty('foo').visibility).to.equal('protected');
+        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('protected');
     })
     it('reflects private', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(new ReflectedClass(B).getProperty('foo').visibility).to.equal('public');
+        expect(ReflectedClass.for(B).getProperty('foo').visibility).to.equal('public');
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_PRIVATE}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(new ReflectedClass(A).getProperty('foo').visibility).to.equal('private');
+        expect(ReflectedClass.for(A).getProperty('foo').visibility).to.equal('private');
     })
     it('reflects readonly', () => {
         class B {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}`, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
-        expect(new ReflectedClass(B).getProperty('foo').isReadonly).to.be.false
+        expect(ReflectedClass.for(B).getProperty('foo').isReadonly).to.be.false
         class A {}
         Reflect.defineMetadata('rt:f', `${flags.F_METHOD}${flags.F_READONLY}`, A.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], A);
-        expect(new ReflectedClass(A).getProperty('foo').isReadonly).to.be.true
+        expect(ReflectedClass.for(A).getProperty('foo').isReadonly).to.be.true
     })
     it('reflects type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => Number, B.prototype, 'foo');
         Reflect.defineMetadata('rt:t', () => String, B.prototype, 'bar');
         Reflect.defineMetadata('rt:P', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects null type as class Object and as null', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => null, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        let prop = new ReflectedClass(B).getProperty('foo');
+        let prop = ReflectedClass.for(B).getProperty('foo');
 
         expect(prop.type.kind === 'literal').to.be.true;
 
@@ -365,102 +366,102 @@ describe('ReflectedProperty', it => {
         Reflect.defineMetadata('rt:t', () => true, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
     })
     it('reflects false type as class Boolean and as false', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => false, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
     })
     it('reflects 123 type as class Number and as 123', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => 123, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(124)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(124)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects string literal type as class String and as the literal', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => 'foobaz', B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(String)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral('foobaz')).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral('not-it')).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('foobaz')).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('not-it')).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects undefined literal type as undefined', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => undefined, B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Object)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Function)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(String)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(undefined)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Object)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Function)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(undefined)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects void type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => ({ TΦ: 'V' }), B.prototype, 'foo');
         Reflect.defineMetadata('rt:P', ['foo'], B);
 
-        expect(new ReflectedClass(B).getProperty('foo').type.kind).to.equal('void');
-        expect(new ReflectedClass(B).getProperty('foo').type.isVoid).to.be.true;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Function)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(String)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(undefined)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(123)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(false)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(true)).to.be.false;
-        expect(new ReflectedClass(B).getProperty('foo').type.isLiteral(null)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.kind).to.equal('void');
+        expect(ReflectedClass.for(B).getProperty('foo').type.isVoid).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Function)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(String)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Boolean)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(undefined)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral('undefined')).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(123)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(false)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(true)).to.be.false;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isLiteral(null)).to.be.false;
     })
     it('reflects static type', () => {
         class B {}
         Reflect.defineMetadata('rt:t', () => Number, B, 'foo');
         Reflect.defineMetadata('rt:t', () => String, B, 'bar');
         Reflect.defineMetadata('rt:SP', ['foo', 'bar'], B);
-        expect(new ReflectedClass(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects type with design:type', () => {
         class B {}
         Reflect.defineMetadata('design:type', Number, B.prototype, 'foo');
         Reflect.defineMetadata('design:type', String, B.prototype, 'bar');
-        expect(new ReflectedClass(B).getProperty('foo').type.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getProperty('bar').type.isClass(String)).to.be.true;
     })
     it('reflects parameter details', () => {
         class B {
@@ -469,14 +470,14 @@ describe('ReflectedProperty', it => {
         Reflect.defineMetadata('rt:t', () => Boolean, B.prototype, 'helloWorld');
         Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], B.prototype, 'helloWorld');
         
-        let helloWorld = new ReflectedClass(B).getMethod('helloWorld');
+        let helloWorld = ReflectedClass.for(B).getMethod('helloWorld');
         expect(helloWorld.parameterNames).to.eql(['message', 'size']);
         expect(helloWorld.parameterTypes[0].isClass(String)).to.be.true;
         expect(helloWorld.parameterTypes[0].isClass(Number)).to.be.false;
         expect(helloWorld.parameterTypes[1].isClass(Number)).to.be.true;
         expect(helloWorld.parameterTypes[1].isClass(String)).to.be.false;
 
-        expect(helloWorld.parameterTypes.map(pt => pt.classConstructor)).to.eql([String, Number]);
+        expect(helloWorld.parameterTypes.map(pt => pt.as('class').class)).to.eql([String, Number]);
     })
     it('reflects static property names with design:type', () => {
         class B {
@@ -484,7 +485,7 @@ describe('ReflectedProperty', it => {
             static bar = 'val';
         }
 
-        expect(new ReflectedClass(B).ownStaticPropertyNames).to.eql(['foo', 'bar']);
+        expect(ReflectedClass.for(B).ownStaticPropertyNames).to.eql(['foo', 'bar']);
     })
     it('reflects static type with design:type', () => {
         class B {
@@ -493,7 +494,7 @@ describe('ReflectedProperty', it => {
         }
         Reflect.defineMetadata('design:type', Number, B, 'foo');
         Reflect.defineMetadata('design:type', String, B, 'bar');
-        expect(new ReflectedClass(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
-        expect(new ReflectedClass(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
+        expect(ReflectedClass.for(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
     })
 });

--- a/src/lib/reflect.test.ts
+++ b/src/lib/reflect.test.ts
@@ -1,6 +1,6 @@
 import { describe } from "razmin";
 import { expect } from "chai";
-import { ReflectedClass } from "./reflect";
+import { ReflectedClass, Interface } from "./reflect";
 import * as flags from '../common/flags';
 
 describe('ReflectedClass', it => {
@@ -441,4 +441,33 @@ describe('ReflectedProperty', it => {
         expect(new ReflectedClass(B).getStaticProperty('foo').type.isClass(Number)).to.be.true;
         expect(new ReflectedClass(B).getStaticProperty('bar').type.isClass(String)).to.be.true;
     })
+    it('reflects reified interfaces', () => {
+        let IΦFoo : Interface = { name: 'Foo', prototype: {}, identity: Symbol('Foo (interface)') };
+
+        Reflect.defineMetadata('rt:P', ['foobar', 'foobaz'], IΦFoo);
+        Reflect.defineMetadata('rt:m', ['helloWorld'], IΦFoo);
+        Reflect.defineMetadata('rt:t', () => Number, IΦFoo.prototype, 'foobar');
+        Reflect.defineMetadata('rt:t', () => String, IΦFoo.prototype, 'foobaz');
+        Reflect.defineMetadata('rt:t', () => Boolean, IΦFoo.prototype, 'helloWorld');
+        Reflect.defineMetadata('rt:p', [{ n: 'message', t: () => String }, { n: 'size', t: () => Number }], IΦFoo.prototype, 'helloWorld');
+
+        let foobar = new ReflectedClass(IΦFoo).getProperty('foobar');
+        let foobaz = new ReflectedClass(IΦFoo).getProperty('foobaz');
+        let helloWorld = new ReflectedClass(IΦFoo).getMethod('helloWorld');
+
+        expect(foobar.type.kind).to.equal('class');
+        expect(foobar.type.isClass(Number)).to.be.true;
+        expect(foobar.type.isClass(String)).to.be.false;
+        
+        expect(foobaz.type.kind).to.equal('class');
+        expect(foobaz.type.isClass(String)).to.be.true;
+        expect(foobaz.type.isClass(Number)).to.be.false;
+        
+        expect(helloWorld.returnType.kind).to.equal('class');
+        expect(helloWorld.returnType.isClass(Boolean)).to.be.true;
+        expect(helloWorld.returnType.isClass(Number)).to.be.false;
+        expect(helloWorld.parameterNames).to.eql(['message', 'size']);
+        expect(helloWorld.parameterTypes.map(pt => pt.classConstructor)).to.eql([String, Number]);
+
+    });
 });

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -107,7 +107,7 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
 
     get kind() : ReflectedTypeRefKind {
         let ref : RtTypeRef = this._ref;
-        if (ref === null || ['string', 'number', 'boolean'].includes(typeof ref))
+        if (ref === null || ['undefined', 'string', 'number', 'boolean'].includes(typeof ref))
             return 'literal';
 
         if (typeof ref === 'object' && 'TΦ' in ref) 
@@ -336,12 +336,11 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
 
     /** @internal */
     static createFromRtRef(ref : RtTypeRef) {
-        if (ref === null || typeof ref !== 'object')
-            return new ReflectedTypeRef(ref);
-        
         let kind : ReflectedTypeRefKind;
         
-        if (typeof ref === 'object' && 'TΦ' in <object>ref)
+        if (ref === null || !['object', 'function'].includes(typeof ref))
+            kind = 'literal';
+        else if (typeof ref === 'object' && 'TΦ' in <object>ref)
             kind = TYPE_REF_KIND_EXPANSION[(ref as RtType).TΦ];
         else if (typeof ref === 'object')
             kind = 'interface';
@@ -820,6 +819,15 @@ export class ReflectedClass<ClassT = any> {
     }
 
     private static reflectedClasses = new WeakMap<object, ReflectedClass>();
+
+    /** 
+     * Create a new ReflectedClass instance for the given type without sharing. Used during testing.
+     * @internal 
+     **/
+    static new<ClassT>(constructorOrInterface : Constructor<ClassT> | Interface) {
+        return new ReflectedClass<ClassT>(<Constructor<ClassT> | Interface>constructorOrInterface);
+    }
+
 
     private static forConstructorOrInterface<ClassT>(constructorOrInterface : Constructor<ClassT> | Interface) {
         let key : object = constructorOrInterface;

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -18,7 +18,6 @@ export function reify(value : Interface): Interface;
  */
 export function reify<InterfaceType>(): Interface;
 export function reify(value? : Interface | typeof NotProvided): Interface {
-    console.log(`REIFY IS RUNNING!`);
     if (value === NotProvided)
         throw new Error(`reify<T>() can only be used when project is built with the typescript-rtti transformer`);
     return value;

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -1,6 +1,17 @@
 import * as Flags from '../common/flags';
 import { getParameterNames } from './get-parameter-names';
 
+export function reflectType<T>(): ReflectedClass {
+    throw new Error(`reflectType() can only be used when project is built with the typescript-rtti transformer`);
+}
+
+/**
+ * Obtain a symbol which uniquely identifies an interface type. Use with: `reify<MyInterface>()`
+ */
+export function reify<InterfaceType>(): Symbol {
+    throw new Error(`reify() can only be used when project is built with the typescript-rtti transformer`);
+}
+
 function Flag(value : string) {
     return (target, propertyKey) => {
         if (!target.flagToProperty)

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -693,6 +693,16 @@ export class ReflectedClass<ClassT = any> {
         return [];
     }
 
+    /**
+     * Check if this class implements the given interface. The parameter can be a reified interface 
+     * reference or a class reference. Note that implementing a class is not the same as extending a class.
+     * 
+     * @param interfaceType 
+     * @returns boolean
+     */
+    implements(interfaceType : Interface | Constructor<any>) {
+        return !!this.interfaces.find(i => typeof interfaceType === 'function' ? i.isClass(interfaceType) : i.isInterface(interfaceType));
+    }
     get prototype() {
         return this._class.prototype;
     }

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -1,11 +1,7 @@
 import * as Flags from '../common/flags';
-import { getParameterNames } from './get-parameter-names';
+import { Interface } from '../common';
 
-export interface Interface {
-    name : string;
-    prototype : any;
-    identity : symbol;
-}
+import { getParameterNames } from './get-parameter-names';
 
 /**
  * Obtain a symbol which uniquely identifies an interface type. Use with: `reify<MyInterface>()`

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -4,6 +4,8 @@ import { Interface, RtVoidType, RtUnknownType, RtAnyType } from '../common';
 import { getParameterNames } from './get-parameter-names';
 import { Sealed } from './sealed';
 
+const NotProvided = Symbol();
+
 /**
  * Obtain a symbol which uniquely identifies an interface type. Use with: `reify<MyInterface>()`
  */
@@ -171,18 +173,29 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
      * @param value 
      * @returns 
      */
-    isLiteral<T>(value : T): this is ReflectedLiteralRef<T> {
-        return this.kind === 'literal' && <unknown>this.ref === value;
+    isLiteral<T = any>(value : T): this is ReflectedLiteralRef<T>;
+    isLiteral(): this is ReflectedLiteralRef<any>;
+    isLiteral(value = NotProvided): boolean
+    {
+        return this.kind === 'literal' && (value === NotProvided || <unknown>this.ref === value);
     }
 
-    is(kind : 'interface'): this is ReflectedInterfaceRef;
-    is(kind : 'class'): this is ReflectedClassRef<any>;
-    is(kind : 'generic'): this is ReflectedGenericRef;
-    is(kind : 'array'): this is ReflectedArrayRef;
-    is(kind : 'intersection'): this is ReflectedIntersectionRef;
-    is(kind : 'union'): this is ReflectedUnionRef;
-    is(kind : 'tuple'): this is ReflectedTupleRef;
-    is(kind : 'void'): this is ReflectedVoidRef;
+    
+    /** Check if this type reference is an interface type    */ is(kind : 'interface'): this is ReflectedInterfaceRef;
+    /** Check if this type reference is a class type         */ is(kind : 'class'): this is ReflectedClassRef<any>;
+    /** Check if this type reference is a generic type       */ is(kind : 'generic'): this is ReflectedGenericRef;
+    /** Check if this type reference is an array type        */ is(kind : 'array'): this is ReflectedArrayRef;
+    /** Check if this type reference is an intersection type */ is(kind : 'intersection'): this is ReflectedIntersectionRef;
+    /** Check if this type reference is a union type         */ is(kind : 'union'): this is ReflectedUnionRef;
+    /** Check if this type reference is a tuple type         */ is(kind : 'tuple'): this is ReflectedTupleRef;
+    /** Check if this type reference is a void type          */ is(kind : 'void'): this is ReflectedVoidRef;
+    /** Check if this type reference is an any type          */ is(kind : 'any'): this is ReflectedAnyRef;
+    /** Check if this type reference is an unknown type      */ is(kind : 'unknown'): this is ReflectedUnknownRef;
+    /** Check if this type reference is a literal type       */ is(kind : 'literal'): this is ReflectedLiteralRef<any>;
+    /**
+     * Check if this type reference is an instance of the given ReflectedTypeRef subclass.
+     * @param type The subclass of ReflectedTypeRef to check
+     */
     is<T, U extends T>(this : T, type : Constructor<U>) : this is U;
     is(this, kind : ReflectedTypeRefKind | Constructor<any>): boolean {
         if (typeof kind === 'function')
@@ -254,20 +267,14 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
         return this;
     }
 
-
-    get isLiteralValue() { return this.kind === 'literal'; }
-    get isTrue() { return this.isLiteral(true); }
-    get isVoid() { return this.kind === 'void'; }
-    get isFalse() { return this.isLiteral(false); }
-    get isNull() { return this.isLiteral(null); }
-    get isStringLiteral() { return typeof this.ref === 'string'; }
-    get isNumberLiteral() { return typeof this.ref === 'number'; }
-    get isBooleanLiteral() { return typeof this.ref === 'boolean'; }
-    get isUndefined() { return this.isLiteral(void 0); }
-
-    get literalValue(): any {
-        return this.kind === 'literal' ? this.ref : void 0;
-    }
+    isVoid():           this is ReflectedVoidRef               { return this.kind === 'void'; }
+    isNull():           this is ReflectedLiteralRef<null>      { return this.isLiteral(null); }
+    isUndefined():      this is ReflectedLiteralRef<undefined> { return this.isLiteral(void 0); }
+    isTrue():           this is ReflectedLiteralRef<true>      { return this.isLiteral(true); }
+    isFalse():          this is ReflectedLiteralRef<false>     { return this.isLiteral(false); }
+    isStringLiteral():  this is ReflectedLiteralRef<string>    { return this.kind === 'literal' && typeof this.ref === 'string'; }
+    isNumberLiteral():  this is ReflectedLiteralRef<number>    { return this.kind === 'literal' && typeof this.ref === 'number'; }
+    isBooleanLiteral(): this is ReflectedLiteralRef<number>    { return this.kind === 'literal' && typeof this.ref === 'boolean'; }
 
     /**
      * Check if this type reference is a generic type, optionally checking if the generic's

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -150,6 +150,15 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
     }
 
     /**
+     * Returns the constructor of this type if it has one. Only valid for class references.
+     */
+    get classConstructor(): Function {
+        if (this.kind !== 'class')
+            return undefined;
+        return <Function><unknown>this.ref;
+    }
+
+    /**
      * Checks if this type is a literal type (null/true/false/undefined or a literal expression)
      * @param value 
      * @returns 
@@ -538,15 +547,27 @@ export class ReflectedMethod extends ReflectedMember {
         if (this._rawParameterMetadata)
             return this._rawParameterMetadata;
         
-        return this._rawParameterMetadata = Reflect.getMetadata('rt:p', this.host, this.name) || [];
+        return this._rawParameterMetadata = Reflect.getMetadata('rt:p', this.host, this.name);
     }
 
     get parameterNames() {
         return this.rawParameterMetadata.map(x => x.n);
     }
 
+    private _parameterTypes : ReflectedTypeRef[];
+
     get parameterTypes() {
-        return this.rawParameterMetadata.map(x => x.t);
+        if (this._parameterTypes !== undefined)
+            return this._parameterTypes;
+        
+        if (this.rawParameterMetadata !== undefined) {
+            return this._parameterTypes = this.rawParameterMetadata.map(param => {
+                return param.t ? ReflectedTypeRef.createFromRtRef(param.t()) : ReflectedTypeRef.createUnknown();
+            });
+        } else if (Reflect.hasMetadata('design:paramtypes', this.host, this.name)) {
+            let params : Function[] = Reflect.getMetadata('design:paramtypes', this.host, this.name);
+            return this._parameterTypes = params.map(t => ReflectedTypeRef.createFromRtRef(() => t));
+        }
     }
 
     get parameters() {
@@ -865,7 +886,7 @@ export class ReflectedClass<ClassT = any> {
         let rawParams = Reflect.getMetadata('rt:p', this.class);
         if (rawParams === void 0 && Reflect.hasMetadata('design:paramtypes', this.class)) {
             let types = Reflect.getMetadata('design:paramtypes', this.class);
-            let names = getParameterNames(this.class);
+            let names = getParameterNames(<Function>this.class);
             rawParams = names.map((n, i) => ({ n, t: () => types[i] }));
         }
 

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -1,14 +1,16 @@
 import * as Flags from '../common/flags';
 import { getParameterNames } from './get-parameter-names';
 
-export function reflectType<T>(): ReflectedClass {
-    throw new Error(`reflectType() can only be used when project is built with the typescript-rtti transformer`);
+export interface Interface {
+    name : string;
+    prototype : any;
+    identity : symbol;
 }
 
 /**
  * Obtain a symbol which uniquely identifies an interface type. Use with: `reify<MyInterface>()`
  */
-export function reify<InterfaceType>(): Symbol {
+export function reify<InterfaceType>(): Interface {
     throw new Error(`reify() can only be used when project is built with the typescript-rtti transformer`);
 }
 
@@ -632,12 +634,12 @@ export class ReflectedProperty extends ReflectedMember {
 
 export class ReflectedClass<ClassT = any> {
     constructor(
-        klass : Constructor<ClassT>
+        klass : Constructor<ClassT> | Interface
     ) {
         this._class = klass;
     }
 
-    private _class : Constructor<ClassT>;
+    private _class : Constructor<ClassT> | Interface;
     private _ownMethods : ReflectedMethod[];
     private _methods : ReflectedMethod[];
     private _ownPropertyNames : string[];

--- a/src/lib/reflect.ts
+++ b/src/lib/reflect.ts
@@ -112,6 +112,13 @@ export class ReflectedTypeRef<T extends RtTypeRef = RtTypeRef> {
         }
     }
 
+    /**
+     * Check if the given value matches this type reference. Collects any errors into the `errors` list.
+     * @param value 
+     * @param errors 
+     * @param context 
+     * @returns 
+     */
     matchesValue(value, errors? : Error[], context? : string) {
         errors.push(new Error(`No validation available for type with kind '${this.kind}'`));
         return false;
@@ -392,8 +399,8 @@ export class ReflectedClassRef<Class> extends ReflectedTypeRef<Constructor<Class
 @ReflectedTypeRef.Kind('interface')
 export class ReflectedInterfaceRef extends ReflectedTypeRef<InterfaceToken> {
     get kind() { return 'interface' as const; }
-    get interface() : InterfaceToken { return this.ref; }
-    toString() { return `interface ${this.interface.name}`; }
+    get token() : InterfaceToken { return this.ref; }
+    toString() { return `interface ${this.token.name}`; }
 
     matchesValue(value: any, errors : Error[] = [], context? : string) {
         return ReflectedClass.for(this.ref).matchesValue(value);
@@ -949,6 +956,10 @@ export class ReflectedClass<ClassT = any> {
 
     private _interfaces : ReflectedTypeRef[];
 
+    /**
+     * Get the interfaces that this class implements.
+     * 
+     */
     get interfaces() {
         if (this._interfaces !== undefined)
             return this._interfaces;

--- a/src/lib/reify.test.ts
+++ b/src/lib/reify.test.ts
@@ -1,0 +1,30 @@
+import { describe } from "razmin";
+import { RunInvocation, runSimple } from "../runner.test";
+
+describe('reify<T>()', it => {
+
+    async function expectError(invocation : RunInvocation) {
+        try {
+            await runSimple(invocation);
+        } catch (e) {
+            return;
+        }
+
+        throw new Error(`Expected error`);
+    }
+
+    it('is an error to call it with an invalid type', async () => {
+        async function badCall(code : string) {
+            await expectError({
+                modules: {
+                    'typescript-rtti': { reify: a => a, reflect: a => a }
+                },
+                code: ` import { reify } from 'typescript-rtti'; ${code}`
+            });
+        }
+
+        await badCall(`reify<Number | String>()`);
+        await badCall(`reify<void>()`);
+        await badCall(`reify<undefined>()`);
+    });
+});

--- a/src/lib/sealed.ts
+++ b/src/lib/sealed.ts
@@ -1,0 +1,6 @@
+export function Sealed() {
+    return (target) => {
+        Object.seal(target)
+        return target;
+    };
+}

--- a/src/lib/value-matches.test.ts
+++ b/src/lib/value-matches.test.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+import { describe } from "razmin";
+import { reflect, ReflectedClass } from ".";
+import { runSimple } from "../runner.test";
+
+describe('ReflectedClass#matchesValue()', it => {
+    it('works with simple interfaces', async () => {
+        let exports = await runSimple({
+            code: `
+                export interface A {
+                    foo : string;
+                    bar : number;
+                    baz : boolean;
+                }
+            `
+        });
+
+        expect(reflect(exports.IΦA).matchesValue({
+            foo: 'hello',
+            bar: 123,
+            baz: true
+        })).to.be.true;
+        
+        expect(reflect(exports.IΦA).matchesValue({
+            foo: 1111,
+            bar: 123,
+            baz: true
+        })).to.be.false;
+    });
+    it('supports literal types', async () => {
+        let exports = await runSimple({
+            code: `
+                export interface A {
+                    foo : 'hello';
+                }
+            `
+        });
+
+        expect(reflect(exports.IΦA).matchesValue({ foo: 'hello' })).to.be.true;
+        expect(reflect(exports.IΦA).matchesValue({ foo: 'hello world' })).to.be.false;
+    });
+});

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,0 +1,154 @@
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import { esRequire } from '../test-esrequire.js';
+import transformer from './transformer';
+
+export interface RunInvocation {
+    code : string;
+    transformerEnabled? : boolean;
+    moduleType? : 'commonjs' | 'esm';
+    compilerOptions? : Partial<ts.CompilerOptions>;
+    modules? : Record<string,any>;
+    trace? : boolean;
+}
+
+function transpilerHost(sourceFile : ts.SourceFile, write : (output : string) => void) {
+    return <ts.CompilerHost>{
+        getSourceFile: (fileName) => {
+            if (fileName === "module.ts")
+                return sourceFile;
+        
+            let libLoc = path.resolve(__dirname, '../node_modules/typescript/lib', fileName);
+            let stat = fs.statSync(libLoc);
+
+            if (!stat.isFile())
+                return;
+            
+            let buf = fs.readFileSync(libLoc);
+
+            return ts.createSourceFile("module.ts", buf.toString('utf-8'), ts.ScriptTarget.Latest);            
+        },
+        writeFile: (name, text) => {
+            if (!name.endsWith(".map"))
+                write(text);
+        },
+        getDefaultLibFileName: () => "lib.d.ts",
+        useCaseSensitiveFileNames: () => false,
+        getCanonicalFileName: fileName => fileName,
+        getCurrentDirectory: () => "",
+        getNewLine: () => "\n",
+        fileExists: (fileName): boolean => fileName === "module.ts",
+        readFile: () => "",
+        directoryExists: () => true,
+        getDirectories: () => []
+    };
+}
+
+export function compile(invocation : RunInvocation): string {
+    let options : ts.CompilerOptions = {
+        ...ts.getDefaultCompilerOptions(),
+        ...<ts.CompilerOptions>{
+            target: ts.ScriptTarget.ES2016,
+            module: ts.ModuleKind.CommonJS,
+            moduleResolution: ts.ModuleResolutionKind.NodeJs,
+            experimentalDecorators: true,
+            lib: ['lib.es2016.d.ts'],
+            noLib: false,
+            emitDecoratorMetadata: false,
+            suppressOutputPathCheck: true,
+            rtti: <any>{ trace: invocation.trace === true }
+        }, 
+        ...invocation.compilerOptions || {},
+    };
+    
+    if (invocation.moduleType) {
+        if (invocation.moduleType === 'esm') 
+            options.module = ts.ModuleKind.ES2020;
+    }
+
+    const sourceFile = ts.createSourceFile("module.ts", invocation.code, options.target!);
+    let outputText: string | undefined;
+    const compilerHost = transpilerHost(sourceFile, output => outputText = output);
+    const program = ts.createProgram(["module.ts"], options, compilerHost);
+
+    let optionsDiags = program.getOptionsDiagnostics();
+    let syntacticDiags = program.getSyntacticDiagnostics();
+
+    if (invocation.trace) {
+        for (let diag of optionsDiags) {
+            console.log(diag);
+        }
+        for (let diag of syntacticDiags) {
+            console.log(diag);
+        }
+    }
+
+    program.emit(undefined, undefined, undefined, undefined, {
+        before: invocation.transformerEnabled !== false ? [ 
+            transformer(program) 
+        ] : []
+    });
+
+    if (outputText === undefined) {
+        if (program.getOptionsDiagnostics().length > 0) {
+            console.dir(program.getOptionsDiagnostics());
+        } else {
+            console.dir(program.getSyntacticDiagnostics(sourceFile));
+        }
+
+        throw new Error(`Failed to compile test code: '${invocation.code}'`);
+    }
+
+    return outputText;
+}
+
+/**
+ * Compile the given code using Typescript and typescript-rtti transformer plugin and return the 
+ * resulting exports.
+ * 
+ * @param invocation 
+ * @returns 
+ */
+export async function runSimple(invocation : RunInvocation) {
+    let outputText = compile(invocation);
+
+    if (invocation.trace) {
+        console.log(`========================`);
+        console.log(outputText);
+        console.log(`========================`);
+    }
+
+    let exports : Record<string,any> = {};
+    let rq = (moduleName : string) => {
+        if (!invocation.modules)
+            throw new Error(`(RTTI Test) Cannot find module '${moduleName}'`);
+            
+        let symbols = invocation.modules[moduleName];
+
+        if (!symbols)
+            throw new Error(`(RTTI Test) Cannot find module '${moduleName}'`);
+
+        return symbols;
+    };
+
+    if (invocation.moduleType === 'esm') {
+
+        global['moduleOverrides'] = invocation.modules;
+
+        exports = await esRequire(
+            `data:text/javascript;base64,${Buffer.from(`
+                ${outputText}
+            `).toString('base64')}`
+        );
+    } else {
+        let func = eval(`(
+            function(exports, require){
+                ${outputText}
+            }
+        )`);
+        func(exports, rq);
+    }
+
+    return exports;
+}

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -35,6 +35,8 @@ import * as ts from 'typescript';
 import { T_ANY, T_ARRAY, T_INTERSECTION, T_THIS, T_TUPLE, T_UNION, T_UNKNOWN, T_GENERIC, T_VOID } from '../common';
 import { cloneEntityNameAsExpr, dottedNameToExpr, entityNameToString, getRootNameOfEntityName } from './utils';
 
+export class CompileError extends Error {}
+
 export interface RttiSettings {
     trace? : boolean;
 }
@@ -862,8 +864,10 @@ const transformer: (program : ts.Program) => ts.TransformerFactory<ts.SourceFile
                                                     console.dir(typeSpecifier);
                                                 }
 
-                                                throw new Error(
-                                                    `RTTI: ${sourceFile.fileName}: reify(): cannot resolve interface ${text || '<unresolvable>'}`);
+                                                throw new CompileError(
+                                                    `RTTI: ${sourceFile.fileName}: reify(): ` 
+                                                    + `cannot resolve interface: ${text || '<unresolvable>'}: Not supported.`
+                                                );
                                             }
 
                                             let typeImport = importMap.get(localName);
@@ -1140,6 +1144,9 @@ const transformer: (program : ts.Program) => ts.TransformerFactory<ts.SourceFile
                     sourceFile.libReferenceDirectives
                 );
             } catch (e) {
+                if (e instanceof CompileError)
+                    throw e;
+                
                 console.error(`RTTI: Failed to build source file ${sourceFile.fileName}: ${e.message} [please report]`);
                 console.error(e);
             }

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -902,10 +902,7 @@ const transformer: (program : ts.Program) => ts.TransformerFactory<ts.SourceFile
                             result.node,
                             ...extractClassMetadata(<ts.InterfaceDeclaration>node, details)
                                 .map(decorator => ts.factory.createCallExpression(decorator.expression, undefined, [
-                                    ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createIdentifier(`IΦ${(node as ts.InterfaceDeclaration).name.text}`), 
-                                        'prototype'
-                                    )
+                                    ts.factory.createIdentifier(`IΦ${(node as ts.InterfaceDeclaration).name.text}`)
                                 ])),
                             ...(result.decorators.map(dec => ts.factory.createCallExpression(dec.decorator.expression, undefined, [
                                 ts.factory.createPropertyAccessExpression(

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -1267,8 +1267,8 @@ describe('RTTI: ', () => {
                 
                 expect(typeRefs).to.exist;
                 expect(typeRefs.length).to.equal(2);
-                expect(typeRefs[0]()).to.equal(exports.Something);
-                expect(typeRefs[1]()).to.equal(exports.SomethingElse);
+                expect(typeRefs[0]()).to.equal(exports.IΦSomething);
+                expect(typeRefs[1]()).to.equal(exports.IΦSomethingElse);
             })
             it('emits for external interfaces implemented by a class', async () => {
                 let IΦSomething : Interface = { 
@@ -1284,6 +1284,7 @@ describe('RTTI: ', () => {
                 };
 
                 let exports = await runSimple({
+                    trace: true,
                     modules: {
                         other: {
                             IΦSomething, IΦSomethingElse
@@ -1300,6 +1301,41 @@ describe('RTTI: ', () => {
                 expect(typeRefs).to.exist;
                 expect(typeRefs.length).to.equal(2);
                 expect(typeRefs[0]()).to.equal(IΦSomething);
+                expect(typeRefs[1]()).to.equal(IΦSomethingElse);
+            })
+            it('prefers exported class over exported interface', async () => {
+                let IΦSomething : Interface = { 
+                    name: 'Something',
+                    prototype: {},
+                    identity: Symbol('Something (interface)')
+                };
+
+                let IΦSomethingElse : Interface = { 
+                    name: 'SomethingElse',
+                    prototype: {},
+                    identity: Symbol('SomethingElse (interface)')
+                };
+
+                class Something {}
+
+                let exports = await runSimple({
+                    trace: true,
+                    modules: {
+                        other: {
+                            Something, IΦSomething, IΦSomethingElse
+                        }
+                    },
+                    code: `
+                        import { Something, SomethingElse } from 'other';
+                        export class C implements Something, SomethingElse {}
+                    `
+                });
+        
+                let typeRefs : any[] = Reflect.getMetadata('rt:i', exports.C);
+                
+                expect(typeRefs).to.exist;
+                expect(typeRefs.length).to.equal(2);
+                expect(typeRefs[0]()).to.equal(Something);
                 expect(typeRefs[1]()).to.equal(IΦSomethingElse);
             })
         });

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -214,7 +214,7 @@ describe('RTTI: ', () => {
         })
         for (let moduleType of MODULE_TYPES) {
             describe(` [${moduleType}]`, it => {
-                it.only('will resolve to the interface symbol generated in another file', async () => {
+                it('will resolve to the interface symbol generated in another file', async () => {
                     let FooSym = "$$FOO";
                     let IΦFoo = { name: 'Foo', prototype: {}, identity: FooSym };
 
@@ -236,7 +236,7 @@ describe('RTTI: ', () => {
                     });
                     expect(exports.ReifiedFoo).to.eql(IΦFoo);
                 })
-                it.only('will not choke if the imported interface has no type metadata', async () => {
+                it('will not choke if the imported interface has no type metadata', async () => {
                     let exports = await runSimple({
                         moduleType: moduleType,
                         code: `

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -814,7 +814,7 @@ describe('RTTI: ', () => {
                 let type = Reflect.getMetadata('rt:t', exports.C.prototype, 'method');
                 expect(type()).to.eql({ TΦ: T_UNKNOWN });
             })
-            it.only('emits for void return type', async () => {
+            it('emits for void return type', async () => {
                 let exports = await runSimple({
                     code: `
                         export class C {

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -190,7 +190,7 @@ describe('RTTI: ', () => {
             expect(Reflect.getMetadata('rt:m', exports.IΦFoo.prototype)).to.eql(['method']);
         });
     });
-    describe('reify()', it => {
+    describe('reify<T>()', it => {
         it('will resolve to the interface symbol generated in the same file', async () => {
             let exports = await runSimple({
                 code: `
@@ -204,12 +204,19 @@ describe('RTTI: ', () => {
                     }
                 }
             });
+
+            let identity = exports.IΦFoo.identity;
+
+            expect(typeof identity).to.equal('symbol');
+            expect(exports.IΦFoo).to.eql({ name: 'Foo', prototype: {}, identity });
             expect(exports.ReifiedFoo).to.equal(exports.IΦFoo);
         })
         for (let moduleType of MODULE_TYPES) {
             describe(`(${moduleType})`, it => {
                 it('will resolve to the interface symbol generated in another file', async () => {
                     let FooSym = "$$FOO";
+                    let IΦFoo = { name: 'Foo', prototype: {}, identity: FooSym };
+
                     let exports = await runSimple({
                         moduleType: moduleType,
                         code: `
@@ -222,11 +229,11 @@ describe('RTTI: ', () => {
                                 reify: () => {}
                             },
                             "another": {
-                                IΦFoo: FooSym
+                                IΦFoo
                             }
                         }
                     });
-                    expect(exports.ReifiedFoo).to.equal(FooSym);
+                    expect(exports.ReifiedFoo).to.eql(IΦFoo);
                 })
 
             });

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -186,8 +186,8 @@ describe('RTTI: ', () => {
             expect(Reflect.getMetadata('rt:t', exports.IΦFoo.prototype, 'blah')()).to.eql({ TΦ: "|", t: [String, Number] });
             expect(Reflect.getMetadata('rt:p', exports.IΦFoo.prototype, 'method')[0].n).to.equal('foo');
             expect(Reflect.getMetadata('rt:p', exports.IΦFoo.prototype, 'method')[0].t()).to.equal(Number);
-            expect(Reflect.getMetadata('rt:P', exports.IΦFoo.prototype)).to.eql(['field', 'blah']);
-            expect(Reflect.getMetadata('rt:m', exports.IΦFoo.prototype)).to.eql(['method']);
+            expect(Reflect.getMetadata('rt:P', exports.IΦFoo)).to.eql(['field', 'blah']);
+            expect(Reflect.getMetadata('rt:m', exports.IΦFoo)).to.eql(['method']);
         });
     });
     describe('reify<T>()', it => {

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -4,7 +4,7 @@ import { describe } from 'razmin';
 import ts from 'typescript';
 import { F_OPTIONAL, F_PRIVATE, F_PROTECTED, F_PUBLIC, F_READONLY } from "./flags";
 import { F_ABSTRACT, F_CLASS, F_EXPORTED, T_ANY, T_ARRAY, T_GENERIC, T_INTERSECTION, T_THIS, T_TUPLE, T_UNION, T_UNKNOWN, T_VOID } from '../common';
-import { Interface } from '../common';
+import { InterfaceToken } from '../common';
 import { runSimple } from '../runner.test';
 import { reify, reflect } from '../lib';
 
@@ -1132,13 +1132,13 @@ describe('RTTI: ', () => {
                 expect(typeRefs[1]()).to.equal(exports.IΦSomethingElse);
             })
             it('emits for external interfaces implemented by a class', async () => {
-                let IΦSomething : Interface = { 
+                let IΦSomething : InterfaceToken = { 
                     name: 'Something',
                     prototype: {},
                     identity: Symbol('Something (interface)')
                 };
 
-                let IΦSomethingElse : Interface = { 
+                let IΦSomethingElse : InterfaceToken = { 
                     name: 'SomethingElse',
                     prototype: {},
                     identity: Symbol('SomethingElse (interface)')
@@ -1164,13 +1164,13 @@ describe('RTTI: ', () => {
                 expect(typeRefs[1]()).to.equal(IΦSomethingElse);
             })
             it('prefers exported class over exported interface', async () => {
-                let IΦSomething : Interface = { 
+                let IΦSomething : InterfaceToken = { 
                     name: 'Something',
                     prototype: {},
                     identity: Symbol('Something (interface)')
                 };
 
-                let IΦSomethingElse : Interface = { 
+                let IΦSomethingElse : InterfaceToken = { 
                     name: 'SomethingElse',
                     prototype: {},
                     identity: Symbol('SomethingElse (interface)')

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -151,7 +151,7 @@ async function runSimple(invocation : RunInvocation) {
 const MODULE_TYPES : ('commonjs' | 'esm')[] = ['commonjs', 'esm'];
 
 describe('RTTI: ', () => {
-    describe('Interfaces', it => {
+    describe('interface', it => {
         it('emits a symbol for every exported interface', async () => {
             let exports = await runSimple({
                 code: `
@@ -159,7 +159,8 @@ describe('RTTI: ', () => {
                 `
             });
 
-            expect(typeof exports.IΦFoo).to.equal('symbol');
+            expect(typeof exports.IΦFoo).to.equal('object');
+            expect(typeof exports.IΦFoo.identity).to.equal('symbol');
         });
         it('emits no symbol for non-exported interface', async () => {
             let exports = await runSimple({
@@ -168,6 +169,25 @@ describe('RTTI: ', () => {
                 `
             });
             expect(exports.IΦFoo).not.to.exist;
+        });
+        it('\'s symbol has type metadata', async () => {
+            let exports = await runSimple({
+                code: `
+                    export interface Foo { 
+                        method(foo : number): boolean;
+                        field : string;
+                        blah : string | number;
+                    }
+                `
+            });
+
+            expect(Reflect.getMetadata('rt:t', exports.IΦFoo.prototype, 'method')()).to.equal(Boolean);
+            expect(Reflect.getMetadata('rt:t', exports.IΦFoo.prototype, 'field')()).to.equal(String);
+            expect(Reflect.getMetadata('rt:t', exports.IΦFoo.prototype, 'blah')()).to.eql({ TΦ: "|", t: [String, Number] });
+            expect(Reflect.getMetadata('rt:p', exports.IΦFoo.prototype, 'method')[0].n).to.equal('foo');
+            expect(Reflect.getMetadata('rt:p', exports.IΦFoo.prototype, 'method')[0].t()).to.equal(Number);
+            expect(Reflect.getMetadata('rt:P', exports.IΦFoo.prototype)).to.eql(['field', 'blah']);
+            expect(Reflect.getMetadata('rt:m', exports.IΦFoo.prototype)).to.eql(['method']);
         });
     });
     describe('reify()', it => {

--- a/src/transformer/transformer.test.ts
+++ b/src/transformer/transformer.test.ts
@@ -214,7 +214,7 @@ describe('RTTI: ', () => {
         })
         for (let moduleType of MODULE_TYPES) {
             describe(` [${moduleType}]`, it => {
-                it('will resolve to the interface symbol generated in another file', async () => {
+                it.only('will resolve to the interface symbol generated in another file', async () => {
                     let FooSym = "$$FOO";
                     let IΦFoo = { name: 'Foo', prototype: {}, identity: FooSym };
 
@@ -236,19 +236,19 @@ describe('RTTI: ', () => {
                     });
                     expect(exports.ReifiedFoo).to.eql(IΦFoo);
                 })
-                it('will not choke if the imported interface has no type metadata', async () => {
+                it.only('will not choke if the imported interface has no type metadata', async () => {
                     let exports = await runSimple({
                         moduleType: moduleType,
                         code: `
                             import { reify } from 'typescript-rtti';
-                            import { Foo } from "another";
+                            import { Foo } from "another2";
                             export const ReifiedFoo = reify<Foo>();
                         `,
                         modules: {
                             "typescript-rtti": { 
                                 reify: () => {}
                             },
-                            "another": {}
+                            "another2": {}
                         }
                     });
 

--- a/src/transformer/utils.ts
+++ b/src/transformer/utils.ts
@@ -31,3 +31,29 @@ export function cloneEntityNameAsExpr(entityName : ts.EntityName, rootName? : st
     else if (ts.isIdentifier(entityName))
         return ts.factory.createIdentifier(entityName.text);
 }
+
+export function qualifiedNameToString(qualifiedName : ts.QualifiedName) {
+    return ts.isIdentifier(qualifiedName.left) 
+        ? qualifiedName.left.text + '.' + qualifiedName.right.text
+        : entityNameToString(qualifiedName.left) + '.' + qualifiedName.right.text
+    ;
+}
+
+export function entityNameToString(entityName : ts.EntityName) {
+    if (ts.isQualifiedName(entityName))
+        return qualifiedNameToString(entityName);
+    else if (ts.isIdentifier(entityName))
+        return entityName.text;
+}
+
+export function dottedNameToExpr(dottedName : string) : ts.Identifier | ts.PropertyAccessExpression {
+    return dottedName
+        .split('.')
+        .map(ident => ts.factory.createIdentifier(ident) as (ts.Identifier | ts.PropertyAccessExpression))
+        .reduce((pv, cv : ts.Identifier) => 
+            pv 
+                ? ts.factory.createPropertyAccessExpression(pv, cv) 
+                : cv
+        )
+    ;
+}

--- a/test-module-resolver.mjs
+++ b/test-module-resolver.mjs
@@ -16,8 +16,12 @@ export async function resolve(url, context, defaultResolve) {
         const DATA = ${JSON.stringify(override)};
         export default DATA;
         ${Object.keys(override)
-            .filter(k => isNaN(k))
+            .filter(k => isNaN(k) && typeof override[k] !== 'function')
             .map(k => `export const ${k} = DATA['${k}']`)
+            .join(";\n")}
+        ${Object.keys(override)
+            .filter(k => isNaN(k) && typeof override[k] === 'function')
+            .map(k => `export const ${k} = (${override[k].toString()})`)
             .join(";\n")}
     `;
 


### PR DESCRIPTION
PR for interfaces support in development.

# Approach 

Modifies interface declarations to emit a real ES value even after interfaces are removed by Typescript. This ES value is exported if the interface is exported, and set as an unexported constant within the source file otherwise. The value for an interface named `Foo` has the name `IΦFoo` and conforms to the `Interface` interface:

```typescript
export interface InterfaceToken {
    name : string;
    prototype : any;
    identity : symbol;
}
```

This value can be obtained by using the `reify<T>(): Interface` function export provided by the runtime layer.

```typescript
interface Foo { }
expect(reify<Foo>().name).to.equal('Foo');
expect(typeof reify<Foo>().identity).to.equal('symbol');
expect(typeof reify<Foo>().prototype).to.equal('object');
```


# Interface Tokens

Obtaining a token for an interface can be done using `reify<T>()`. This token describes the name of the interface as defined at the declaration site, an empty `prototype` object for hanging property metadata onto, and an `identity` symbol that can be used to represent the interface should it be required. "Class" level metadata is hung onto the Interface token object itself.

The token adheres to the following interface:

```typescript
export interface Foo { 
    method(foo : number): boolean;
    field : string;
    blah : string | number;
}
```

You can use `reify<T>()` to obtain an interface token:

```typescript
import { ReflectedClass, reify } from 'typescript-rtti';

interface Foo { 
    foo : string;
}

let reflectedClass = new ReflectedClass(reify<Foo>());
expect(reflectedClass.getProperty('foo').type.isClass(String)).to.be.true;
```

The interface token object can be used with the `ReflectedClass` API:

```typescript
let reflectedInterface = ReflectedClass.from(reify<Something>());
```

This PR also introduces `reflect()` which is a quick uniform way to use the `ReflectedClass` API to reflect upon classes, interfaces and class instances: 

```typescript
let reflectedInterface = reflect<MyInterface>();
let reflectedClass = reflect(MyClass);
```

It also works with constructors and values

```typescript
let reflectedClass = reflect(MyClass);
expect(reflectedClass).to.equal(reflect(new MyClass()));
```

# Simple Validation

A simple API is provided for validating values against a reflected class or interface:

```typescript
interface MyInterface {
    foo : string;
}
expect(reflect<MyInterface>().matchesValue({ foo: 123 })).to.be.false;
```

# Output

```typescript
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.IΦFoo = void 0;
const __RtΦ = (k, v) => Reflect.metadata(k, v);
const IΦFoo = { name: "Foo", prototype: {}, identity: Symbol("Foo (interface)") };
exports.IΦFoo = IΦFoo;
__RtΦ("rt:P", ["field", "blah"])(IΦFoo)
__RtΦ("rt:m", ["method"])(IΦFoo)
__RtΦ("rt:f", "C$e")(IΦFoo)
__RtΦ("rt:p", [{ n: "foo", t: () => Number }])(IΦFoo.prototype, "method")
__RtΦ("rt:f", "M$")(IΦFoo.prototype, "method")
__RtΦ("rt:t", () => Boolean)(IΦFoo.prototype, "method")
__RtΦ("rt:t", () => String)(IΦFoo.prototype, "field")
__RtΦ("rt:f", "P$")(IΦFoo.prototype, "field")
__RtΦ("rt:t", () => ({ TΦ: "|", t: [String, Number] }))(IΦFoo.prototype, "blah")
__RtΦ("rt:f", "P$")(IΦFoo.prototype, "blah")
```

# Punch List
- [x] Use Iphi not Iphi.prototype for rt:m and rt:P
- [x] Support for checking if a specific ReflectedClass implements an interface reference acquired using `reify<T>()` 
- [x] Support for checking if a value matches the shape of a ReflectedClass
- [x] Convenient way to check if a value's constructor implements an interface, perhaps an `implements()` export (ie `if (implements(aValue, reify<MyInterface>())) { ... }`)
- [x] Convenient way to check if a value matches the shape of a constructor or `Interface` value (as provided by `reify<T>()`). Perhaps `if (matchesShape(aValue, reify<MyInterface>())) { ... }`
- [x] Calling reify<T> on anything we don't yet support is an error
- [ ] ~~Framework for representing complex types on the fly, like `reify<Some | Other>()`~~ 
    https://github.com/rezonant/typescript-rtti/issues/8
